### PR TITLE
fixed typo: Gradle -> Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Violation Comments to GitLab Maven Plugin [![Build Status](https://travis-ci.org/tomasbjerre/violation-comments-to-gitlab-maven-plugin.svg?branch=master)](https://travis-ci.org/tomasbjerre/violation-comments-to-gitlab-maven-plugin) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/se.bjurr.violations/violation-comments-to-gitlab-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/se.bjurr.violations/violation-comments-to-gitlab-maven-plugin) [ ![Bintray](https://api.bintray.com/packages/tomasbjerre/tomasbjerre/se.bjurr.violations%3Aviolation-comments-to-gitlab-maven-plugin/images/download.svg) ](https://bintray.com/tomasbjerre/tomasbjerre/se.bjurr.violations%3Aviolation-comments-to-gitlab-maven-plugin/_latestVersion)
-This is a Gradle plugin for [Violation Comments to GitLab Lib](https://github.com/tomasbjerre/violation-comments-to-gitlab-lib).
+This is a Maven plugin for [Violation Comments to GitLab Lib](https://github.com/tomasbjerre/violation-comments-to-gitlab-lib).
 
 It can parse results from static code analysis and comment merge requests in GitLab with them.
 


### PR DESCRIPTION
**Summary**

Fixes a typo in which the README says that this is a Gradle plugin, when in fact it is a Maven plugin.