### PR TITLE
Giving access to the commentOnlyChangedContentContext parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Here is an example:
 					<mergeRequestIid>${GITLAB_mergeRequestIid}</mergeRequestIid>
 					<projectId>${GITLAB_PROJECTID}</projectId>
 					<commentOnlyChangedContent>true</commentOnlyChangedContent>
+					<commentOnlyChangedContentContext>0</commentOnlyChangedContentContext>
 					<createCommentWithAllSingleFileComments>true</createCommentWithAllSingleFileComments>
 					<createSingleFileComments>true</createSingleFileComments>
 					<keepOldComments>false</keepOldComments>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<changelog>1.78</changelog>
-		<violation-comments-lib>1.86.3</violation-comments-lib>
+		<violation-comments-lib>1.86.4</violation-comments-lib>
 		<violations-lib>1.144.5</violations-lib>
 		<fmt>2.6.0</fmt>
 	</properties>

--- a/src/main/java/se/bjurr/violations/comments/github/maven/ViolationCommentsMojo.java
+++ b/src/main/java/se/bjurr/violations/comments/github/maven/ViolationCommentsMojo.java
@@ -27,6 +27,9 @@ public class ViolationCommentsMojo extends AbstractMojo {
   @Parameter(property = "commentOnlyChangedContent", required = false, defaultValue = "true")
   private boolean commentOnlyChangedContent;
 
+  @Parameter(property = "commentOnlyChangedContentContext", required = false)
+  private Integer commentOnlyChangedContentContext = 0;
+
   @Parameter(property = "commentOnlyChangedFiles", required = false, defaultValue = "true")
   private boolean commentOnlyChangedFiles;
 
@@ -160,6 +163,7 @@ public class ViolationCommentsMojo extends AbstractMojo {
           .setApiToken(this.apiToken)
           .setTokenType(tokenType)
           .setCommentOnlyChangedContent(this.commentOnlyChangedContent) //
+          .setCommentOnlyChangedContentContext(this.commentOnlyChangedContentContext) //
           .withShouldCommentOnlyChangedFiles(this.commentOnlyChangedFiles) //
           .setCreateCommentWithAllSingleFileComments(
               this.createCommentWithAllSingleFileComments) //

--- a/violation-comments-to-gitlab-maven-plugin-example/pom.xml
+++ b/violation-comments-to-gitlab-maven-plugin-example/pom.xml
@@ -24,6 +24,7 @@
 					<mergeRequestIid>${GITLAB_MERGEREQUESTIID}</mergeRequestIid>
 					<projectId>${GITLAB_PROJECTID}</projectId>
 					<commentOnlyChangedContent>true</commentOnlyChangedContent>
+					<commentOnlyChangedContentContext>0</commentOnlyChangedContentContext>
 					<createCommentWithAllSingleFileComments>true</createCommentWithAllSingleFileComments>
 					<createSingleFileComments>true</createSingleFileComments>
 					<keepOldComments>false</keepOldComments>


### PR DESCRIPTION
Could not really test this, just went with all the cases where commentOnlyChangedContent was used and adjusted for commentOnlyChangedContentContext